### PR TITLE
CandidateのisCreatedが更新されない場合のエラーハンドリング

### DIFF
--- a/generate_tetrahedron.py
+++ b/generate_tetrahedron.py
@@ -1,8 +1,8 @@
 import random
-import copy
 import numpy as np
 import numpy.linalg as LP
 import itertools
+import time
 
 
 class Tetra():
@@ -121,9 +121,10 @@ def calcCircumsphere(point):
     return circumcenter, circumradius
 
 ####### MAIN #######
+start = time.time()
 
 ## 生成したい四面体の個数をここで指定:
-num = 100
+num = 2000
 threshold = 20 ##くっつける頂点の距離の閾値. 2つの頂点間の距離が, 閾値以下の場合に四面体同士がくっつく.
 
 print('generate '+str(num)+' tetrahedron.')
@@ -170,15 +171,6 @@ while len(tetra_set) < num:
                 for target_tetra in tetra_set:
                     if merged:
                         break
-                        
-#                     print("candidate_triangle: ")
-#                     print([candidate_tetra.triangle[0], candidate_tetra.triangle[1], candidate_tetra.triangle[2], candidate_tetra.triangle[3]])
-#                     print("target_triangle: ")
-#                     print([target_tetra.triangle[0], target_tetra.triangle[1], target_tetra.triangle[2], target_tetra.triangle[3]])
-#                     print("candidate_points: ")
-#                     print(candidate_tetra.point)
-#                     print("target_points: ")
-#                     print(target_tetra.point)
 
                     ## edgeは元々のままだと３次元配列. 重複するedgeを検出する処理のために2次元配列に平坦化.
                     candidate_edges = tuple(map(list, (map(itertools.chain.from_iterable, candidate_tetra.edge))))
@@ -193,76 +185,65 @@ while len(tetra_set) < num:
                         candidate_point = candidate_tetra.point[3] ## 末尾の頂点.
                         ## くっつく可能性のある頂点 = 共有している辺以外の頂点２つ.　= 「candidate_tetraとtarget_tetraに共通しない要素」とtarget_tetraに共通する要素
                         target_points = list(map(list, (set2D(candidate_tetra.point) ^ set2D(target_tetra.point)) & set2D(target_tetra.point)))
-
                         
                         ## 2つの四面体が共有する辺.
                         shared_edge = list(map(list, set2D(candidate_tetra.point) & set2D(target_tetra.point)))
+                        
+                        ## 発生率はかなり低いが, 稀にcandidate_pointがshared_edgeに含まれる
+                        ## =新規で作成された頂点が既存の他の頂点にたまたま一致することがある.
+                        ## この場合は何もしないので、 それをハンドリング.
+                        if not candidate_point in shared_edge:
 
-                        for target_point in target_points:                            
-#                             print("target_point: ")
-#                            print(target_point)
-                            if LP.norm(np.array(target_point)-np.array(candidate_point)) < threshold: ##閾値以下の場合
-                                
-                                ##isCreatedの更新
-                                ## candidate_tetraにおける, candidate_point, 共通する辺の頂点から成る三角形の番号を取得
-                                candidate_updated = False
-                                target_updated = False
-                                
-                                for k in range(0, 4):
-                                    if len(set2D(candidate_tetra.triangle[k]) & set2D([shared_edge[0], shared_edge[1], candidate_point])) == 3:
-                                        candidate_tetra.isCreated[k] = 1
-                                        ## print("candidateのisCreated更新")
-                                        candidate_updated = True
-                                        break
+                            for target_point in target_points:                            
+                                if LP.norm(np.array(target_point)-np.array(candidate_point)) < threshold: ##閾値以下の場合
+
+                                    ##isCreatedの更新
+                                    ## candidate_tetraにおける, candidate_point, 共通する辺の頂点から成る三角形の番号を取得
+                                    candidate_updated = False
+                                    target_updated = False
+
+                                    for k in range(0, 4):
+                                        if len(set2D(candidate_tetra.triangle[k]) & set2D([shared_edge[0], shared_edge[1], candidate_point])) == 3:
+                                            candidate_tetra.isCreated[k] = 1
+                                            ## print("candidateのisCreated更新")
+                                            candidate_updated = True
+                                            break
+
+                                    if not candidate_updated: ## debug
+                                        print("error: Candidate's isCreated Not Updated.")
                                         
-                                if not candidate_updated: ## debug
-                                    print("error: Candidate's isCreated Not Updated.")
-                                    print("candidate_tetra.point: ")
-                                    print([candidate_tetra.point[0], candidate_tetra.point[1], candidate_tetra.point[2], candidate_tetra.point[3]])
-                                    print("target_tetra.point: ")
-                                    print([target_tetra.point[0], target_tetra.point[1], target_tetra.point[2], target_tetra.point[3]])
-                                    print("candidate_point: ")
-                                    print(candidate_point)
-                                    print("target_point: ")
-                                    print(target_point)
-                                    print("target_points: ")
-                                    print(target_points)
-                                    print("shared_edge: ")
-                                    print(shared_edge)
-                                    print("target_triangles: ")
-                                    print(target_tetra.triangle)
-                                    print("11/14 note: 低確率だが偶に新規で生成された頂点がtarget_tetraの頂点に元から一致していることがある.動作には影響しない")
+                                    ## 既存の四面体における, target_point, 共通する辺の頂点から成る三角形の番号を取得
+                                    for k in range(0, 4):
+                                        if len(set2D(target_tetra.triangle[k]) & set2D([shared_edge[0], shared_edge[1], target_point])) == 3: 
+                                            target_tetra.isCreated[k] = 1
+                                            ## print("targetのisCreated更新")
+                                            target_updated = True
+                                            break
 
-                                ## 既存の四面体における, target_point, 共通する辺の頂点から成る三角形の番号を取得
-                                for k in range(0, 4):
-                                    if len(set2D(target_tetra.triangle[k]) & set2D([shared_edge[0], shared_edge[1], target_point])) == 3: 
-                                        target_tetra.isCreated[k] = 1
-                                        ## print("targetのisCreated更新")
-                                        target_updated = True
-                                        break
-                                
-                                if not target_updated: ## debug
-                                    print("error: Target's isCreated Not Updated.")
-                                    print("candidate_tetra.point: ")
-                                    print([candidate_tetra.point[0], candidate_tetra.point[1], candidate_tetra.point[2], candidate_tetra.point[3]])
-                                    print("target_tetra.point: ")
-                                    print([target_tetra.point[0], target_tetra.point[1], target_tetra.point[2], target_tetra.point[3]])
-                                    print("candidate_point: ")
-                                    print(candidate_point)
-                                    print("target_point: ")
-                                    print(target_point)
-                                    print("target_points: ")
-                                    print(target_points)
-                                    print("shared_edge: ")
-                                    print(shared_edge)
-                                    print("target_triangles: ")
-                                    print(target_tetra.triangle)
-                                    
-                                candidate_tetra.point[3] = target_point
-                                ## print("merge")
-                                merged = True
-                                break
-                
+                                    if not target_updated: ## debug
+                                        print("error: Target's isCreated Not Updated.")
+                                        
+                                    if candidate_updated == False or target_updated == False:
+                                        print("candidate_tetra.point: ")
+                                        print([candidate_tetra.point[0], candidate_tetra.point[1], candidate_tetra.point[2], candidate_tetra.point[3]])
+                                        print("target_tetra.point: ")
+                                        print([target_tetra.point[0], target_tetra.point[1], target_tetra.point[2], target_tetra.point[3]])
+                                        print("candidate_point: ")
+                                        print(candidate_point)
+                                        print("target_point: ")
+                                        print(target_point)
+                                        print("target_points: ")
+                                        print(target_points)
+                                        print("shared_edge: ")
+                                        print(shared_edge)
+                                        print("target_triangles: ")
+                                        print(target_tetra.triangle)
+
+                                    candidate_tetra.point[3] = target_point
+                                    ## print("merge")
+                                    merged = True
+                                    break
+
                 
                 ## 一覧に追加
                 new_tetra = Tetra(candidate_tetra.point[0], candidate_tetra.point[1], candidate_tetra.point[2], candidate_tetra.point[3])
@@ -271,7 +252,8 @@ while len(tetra_set) < num:
                 ## isCreatedを更新
                 tetra_set[i].isCreated[target] = 1
                 
-                print("processing...("+'{:.1f}'.format((len(tetra_set)-1)/num*100)+"%)")
+                print("\r"+"processing...("+'{:.1f}'.format((len(tetra_set)-1)/num*100)+"%)",end="")
                 if(len(tetra_set)-1 == num): break
 
-print("completed.")
+elapsed_time = time.time() - start
+print("\n"+"completed. ({:.4g}".format(elapsed_time) + "s)")


### PR DESCRIPTION
### 起こっていること
- マージ処理の際、たまにCandidateのisCreatedが動作しないことがある.

### 原因
- debug用のログを出力すると,shared_edgeに含まれる頂点とcandidate_pointが一致していた. 新規で作成されたcandidate_pointが, たまたま既存の頂点の座標に重なっている. 現行のロジックでは, 「shared_edgeはcandidate_pointとは異なる」という前提のもとに計算を進めており, そのためcandidate_pointをshared_edge以外の頂点に移動させ, candidate_point, shared_edgeが持つ２頂点の３点で面が新しく作られたところを確認, isCreatedを更新という流れになっている. 今回のエラーが起こる場合candidate_pointはshared_edgeに含まれるので, 「3点」が一致する面は存在しない. したがってisCreatedが更新されない, という挙動になる. バグでありながらこの挙動はある意味正しい. しかしその結果, candidate_pointがおかしな位置に飛ばされてしまうので, これ自体は避けたい.

### 対処法
- このような場合は, マージ処理を行わないようにエラーハンドリングする必要がある.そこで, shared_edgeがもとまった時点で以下のif文を追記した.
```
if not candidate_point in shared_edge:
```
これによって, 今回のケースではマージ処理をスキップできる.