### PR TITLE
ループ処理実行中に配列長が変化してしまう問題を解消

### DIFF
--- a/module/GenerateObject.py
+++ b/module/GenerateObject.py
@@ -23,12 +23,14 @@ def GenerateObject(num, threshold, k, vert, d_max, gene_array, attempt):
     # 初期化処理終了
 
     # 各ループで生成される四面体の総数を記録
-    last_tetra_num = 1
+    diff = 1
 
-    while last_tetra_num != 0:
-        last_tetra_num = 0
+    while diff != 0:
+        diff = 0
 
-        for tetra in tetras:
+        prev_tetras = tetras.copy()
+
+        for tetra in prev_tetras:
             if LP.norm(tetra.centroid - vert) > d_max:
                 continue
 
@@ -91,7 +93,7 @@ def GenerateObject(num, threshold, k, vert, d_max, gene_array, attempt):
 
                 # 一覧に追加
                 tetras.append(validated_tetra)
-                last_tetra_num += 1
+                diff += 1
 
                 print("\r"+"processing...( number of tetras: " +
                       '{:.1f}'.format(len(tetras))+")", end="")


### PR DESCRIPTION
今までは、四面体の生成処理を行うループ中に
```python
tetra in tetras
```
のコードにおける``tetras``が更新されていくために、配列長が動的に変化し、新規生成された四面体からさらに四面体が新規生成される、といった問題が発生していた。この問題を解消するために、``tetras``を各ループが終了するたびに複製したものを``prev_tetras``に保存し、
```python
tetra in prev_tetras
```
とすることで配列長が変化しないようにした。